### PR TITLE
vcpkg with all SleepEngine dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@ bld/
 Pipfile
 Pipfile.lock
 *egg-info*
+packages.config
+packages

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "vcpkg"]
+  path = vcpkg
+  url = https://github.com/Microsoft/vcpkg.git 

--- a/SleepEngine/Engine/Render/GameRenderer.cpp
+++ b/SleepEngine/Engine/Render/GameRenderer.cpp
@@ -133,7 +133,7 @@ void GameRenderer::render()
         float const scaleX = camera.getScreenWidth() / windowSize.x;
         float const scaleY = camera.getScreenHeight() / windowSize.y;
 
-        float const farDistance = globalEngineConfig()->getData().MaxLayer + 1;
+        float const farDistance = static_cast <float>(globalEngineConfig()->getData().MaxLayer + 1);
 
         glm::mat4 projection = glm::ortho(
             -scaleX,

--- a/SleepEngine/Engine/Utils/file_utils.cpp
+++ b/SleepEngine/Engine/Utils/file_utils.cpp
@@ -2,26 +2,16 @@
 #include "file_utils.h"
 #include <fmt/ostream.h>
 
+
 std::optional<std::string> readFile(std::filesystem::path path)
 {
-    if (!std::filesystem::exists(path))
+    std::ifstream stream(path, std::fstream::in | std::fstream::binary);
+
+    if (!stream.is_open())
     {
+        LOG_AND_FAIL_ERROR("Cannot open file '{}'", path);
         return std::nullopt;
     }
-
-    std::uintmax_t bytesCount = std::filesystem::file_size(path);
-    std::string data(bytesCount, '#');
-    std::ifstream fstream;
-
-    if (fstream.is_open())
-    {
-        LOG_AND_FAIL_ERROR("file already open : {}", path);
-        return std::nullopt;
-    }
-
-    fstream.open(path, std::fstream::in | std::fstream::binary);
-    fstream.read(data.data(), bytesCount);
-    fstream.close();
-
-    return data;
+    
+    return std::string(std::istreambuf_iterator<char>(stream), std::istreambuf_iterator<char>());
 }

--- a/SleepEngine/Engine/Utils/file_utils.h
+++ b/SleepEngine/Engine/Utils/file_utils.h
@@ -1,4 +1,5 @@
+// Copyright 2019 Taras Martinyuk, Tihran Katolikian
+
 #pragma once
 
-// if file does not exists, or open or read operation failed, returns empty string
 std::optional<std::string> readFile(std::filesystem::path path);

--- a/SleepEngine/SleepEngine.vcxproj
+++ b/SleepEngine/SleepEngine.vcxproj
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="packages\vcpkg.E.sleep.vcpkg.1.0.0\build\native\vcpkg.E.sleep.vcpkg.props" Condition="Exists('packages\vcpkg.E.sleep.vcpkg.1.0.0\build\native\vcpkg.E.sleep.vcpkg.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -270,8 +271,17 @@
     <None Include="Engine\Config\config.json" />
     <None Include="Engine\Render\Shaders\shader.fs" />
     <None Include="Engine\Render\Shaders\shader.vs" />
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
+    <Import Project="packages\vcpkg.E.sleep.vcpkg.1.0.0\build\native\vcpkg.E.sleep.vcpkg.targets" Condition="Exists('packages\vcpkg.E.sleep.vcpkg.1.0.0\build\native\vcpkg.E.sleep.vcpkg.targets')" />
   </ImportGroup>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('packages\vcpkg.E.sleep.vcpkg.1.0.0\build\native\vcpkg.E.sleep.vcpkg.props')" Text="$([System.String]::Format('$(ErrorText)', 'packages\vcpkg.E.sleep.vcpkg.1.0.0\build\native\vcpkg.E.sleep.vcpkg.props'))" />
+    <Error Condition="!Exists('packages\vcpkg.E.sleep.vcpkg.1.0.0\build\native\vcpkg.E.sleep.vcpkg.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\vcpkg.E.sleep.vcpkg.1.0.0\build\native\vcpkg.E.sleep.vcpkg.targets'))" />
+  </Target>
 </Project>

--- a/SleepEngine/SleepEngine.vcxproj
+++ b/SleepEngine/SleepEngine.vcxproj
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="packages\vcpkg.E.sleep.vcpkg.1.0.0\build\native\vcpkg.E.sleep.vcpkg.props" Condition="Exists('packages\vcpkg.E.sleep.vcpkg.1.0.0\build\native\vcpkg.E.sleep.vcpkg.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -275,13 +274,12 @@
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
-    <Import Project="packages\vcpkg.E.sleep.vcpkg.1.0.0\build\native\vcpkg.E.sleep.vcpkg.targets" Condition="Exists('packages\vcpkg.E.sleep.vcpkg.1.0.0\build\native\vcpkg.E.sleep.vcpkg.targets')" />
+    <Import Project="packages\sleep_dependencies.1.0.0\build\native\sleep_dependencies.targets" Condition="Exists('packages\sleep_dependencies.1.0.0\build\native\sleep_dependencies.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('packages\vcpkg.E.sleep.vcpkg.1.0.0\build\native\vcpkg.E.sleep.vcpkg.props')" Text="$([System.String]::Format('$(ErrorText)', 'packages\vcpkg.E.sleep.vcpkg.1.0.0\build\native\vcpkg.E.sleep.vcpkg.props'))" />
-    <Error Condition="!Exists('packages\vcpkg.E.sleep.vcpkg.1.0.0\build\native\vcpkg.E.sleep.vcpkg.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\vcpkg.E.sleep.vcpkg.1.0.0\build\native\vcpkg.E.sleep.vcpkg.targets'))" />
+    <Error Condition="!Exists('packages\sleep_dependencies.1.0.0\build\native\sleep_dependencies.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\sleep_dependencies.1.0.0\build\native\sleep_dependencies.targets'))" />
   </Target>
 </Project>

--- a/SleepEngine/SleepEngine.vcxproj.filters
+++ b/SleepEngine/SleepEngine.vcxproj.filters
@@ -208,5 +208,6 @@
     <None Include="Engine\Render\Shaders\shader.vs" />
     <None Include="Engine\Render\Shaders\shader.fs" />
     <None Include="Engine\Config\config.json" />
+    <None Include="packages.config" />
   </ItemGroup>
 </Project>

--- a/scripts/install_dependencies.bat
+++ b/scripts/install_dependencies.bat
@@ -5,6 +5,18 @@ set SCRIPTS_PATH=%cd%
 
 cd ..\vcpkg
 
+
+@echo on
+@echo Installing vcpkg...
+@echo off
+
+call bootstrap-vcpkg.bat
+
+@echo on
+@echo Done.
+@echo Installing dependencies...
+@echo off
+
 vcpkg.exe install opengl glfw3 glm glad stb spdlog nlohmann-json
 
 @echo on

--- a/scripts/install_dependencies.bat
+++ b/scripts/install_dependencies.bat
@@ -1,0 +1,9 @@
+@echo Project dependencies will be installed with vcpkg.
+
+cd ..\vcpkg
+
+FOR %%P IN (opengl glfw3 glm glad stb spdlog nlohmann-json) DO vcpkg.exe install %%P
+
+cd ..\scripts
+
+@echo Done.

--- a/scripts/install_dependencies.bat
+++ b/scripts/install_dependencies.bat
@@ -1,9 +1,48 @@
 @echo Project dependencies will be installed with vcpkg.
+@echo off
+
+set SCRIPTS_PATH=%cd%
 
 cd ..\vcpkg
 
-FOR %%P IN (opengl glfw3 glm glad stb spdlog nlohmann-json) DO vcpkg.exe install %%P
+vcpkg.exe install opengl glfw3 glm glad stb spdlog nlohmann-json
 
-cd ..\scripts
+@echo on
+@echo Done.
+@echo Creating a package...
+@echo off
 
+vcpkg.exe integrate project
+
+cd scripts\buildsystems\tmp
+
+del *.nuspec
+
+@echo on
+copy %SCRIPTS_PATH%\vcpkg.nuget.nuspec %cd%
+@echo off
+
+cd ..
+
+del *.nupkg
+
+cd ..\..\downloads\tools\nuget-4.6.2-windows
+
+nuget.exe pack ..\..\..\scripts\buildsystems\tmp\vcpkg.nuget.nuspec
+
+move sleep_dependencies*.nupkg ..\..\..\scripts\buildsystems
+
+cd ..\..\..\scripts\buildsystems
+
+@echo on
+@echo -------------------------------------------------------------------------------------------
+@echo -------------------------------------------------------------------------------------------
+@echo -- Now, please, go to NuGet console of your 'sleep' ---------------------------------------
+@echo -- project and execute the following script: ----------------------------------------------
+@echo -- Install-Package sleep_dependencies -Source "%cd%"
+@echo -------------------------------------------------------------------------------------------
+
+cd %SCRIPTS_PATH%
+
+@echo on
 @echo Done.

--- a/scripts/vcpkg.nuget.nuspec
+++ b/scripts/vcpkg.nuget.nuspec
@@ -1,0 +1,14 @@
+
+<package>
+    <metadata>
+        <id>sleep_dependencies</id>
+        <version>1.0.0</version>
+        <authors>vcpkg</authors>
+        <description>
+            sleep dependencies
+        </description>
+    </metadata>
+    <files>
+        <file src="vcpkg.nuget.targets" target="build\native\sleep_dependencies.targets" />
+    </files>
+</package>


### PR DESCRIPTION
Now our repository has its own vcpkg.
Anyone who want to compile it now should clone sleep engine, then go to **scripts** and execute _install_dependencies.bat_. It will install all engine libraries to our local instance of **vcpkg**.